### PR TITLE
embree: import cross compile fixes.

### DIFF
--- a/thirdparty/embree/common/math/math.h
+++ b/thirdparty/embree/common/math/math.h
@@ -13,7 +13,7 @@
 #include <immintrin.h>
 
 #if defined(__WIN32__)
-#if (__MSV_VER <= 1700)
+#if defined(_MSC_VER) && (_MSC_VER <= 1700)
 namespace std
 {
   __forceinline bool isinf ( const float x ) { return _finite(x) == 0; }
@@ -86,7 +86,7 @@ namespace embree
     return _mm_cvtss_f32(c);
   }
 
-#if defined(__WIN32__) && (__MSC_VER <= 1700)
+#if defined(__WIN32__) && defined(_MSC_VER) && (_MSC_VER <= 1700)
   __forceinline float nextafter(float x, float y) { if ((x<y) == (x>0)) return x*(1.1f+float(ulp)); else return x*(0.9f-float(ulp)); }
   __forceinline double nextafter(double x, double y) { return _nextafter(x, y); }
   __forceinline int roundf(float f) { return (int)(f + 0.5f); }

--- a/thirdparty/embree/common/sys/library.cpp
+++ b/thirdparty/embree/common/sys/library.cpp
@@ -27,7 +27,7 @@ namespace embree
 
   /* returns address of a symbol from the library */
   void* getSymbol(lib_t lib, const std::string& sym) {
-    return GetProcAddress(HMODULE(lib),sym.c_str());
+    return (void*)GetProcAddress(HMODULE(lib),sym.c_str());
   }
 
   /* closes the shared library */


### PR DESCRIPTION
Fix typos in #if and nonstandard implicit cast.
Collectively, these two fixes allow embree to be cross compiled using llvm-mingw on Linux:
Note that in addition to fixing the typo with _MSC_VER, the defined check must be added to avoid undefined symbols acting as 0.
See https://github.com/embree/embree/pull/310